### PR TITLE
Add GET Engine API call

### DIFF
--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/EnterpriseSearch.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/EnterpriseSearch.java
@@ -55,6 +55,8 @@ import java.util.function.Supplier;
 public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemIndexPlugin {
     private static final Logger logger = LogManager.getLogger(EnterpriseSearch.class);
 
+    public static final String ENDPOINT = "_engine";
+
     public static final String FEATURE_NAME = "ent_search";
 
     private final boolean enabled;

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/EnterpriseSearch.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/EnterpriseSearch.java
@@ -40,11 +40,13 @@ import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.entsearch.engine.EngineIndexService;
+import org.elasticsearch.xpack.entsearch.engine.action.GetEngineAction;
 import org.elasticsearch.xpack.entsearch.engine.action.PutEngineAction;
+import org.elasticsearch.xpack.entsearch.engine.action.RestGetEngineAction;
 import org.elasticsearch.xpack.entsearch.engine.action.RestPutEngineAction;
+import org.elasticsearch.xpack.entsearch.engine.action.TransportGetEngineAction;
 import org.elasticsearch.xpack.entsearch.engine.action.TransportPutEngineAction;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -71,7 +73,10 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
             return Collections.emptyList();
         }
         // Register new actions here
-        return List.of(new ActionHandler<>(PutEngineAction.INSTANCE, TransportPutEngineAction.class));
+        return List.of(
+            new ActionHandler<>(PutEngineAction.INSTANCE, TransportPutEngineAction.class),
+            new ActionHandler<>(GetEngineAction.INSTANCE, TransportGetEngineAction.class)
+        );
     }
 
     @Override
@@ -89,7 +94,7 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
             return Collections.emptyList();
         }
         // Register new actions here
-        return List.of(new RestPutEngineAction());
+        return List.of(new RestPutEngineAction(), new RestGetEngineAction());
     }
 
     @Override
@@ -122,7 +127,7 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
 
     @Override
     public Collection<SystemIndexDescriptor> getSystemIndexDescriptors(Settings settings) {
-        return Arrays.asList(EngineIndexService.getSystemIndexDescriptor());
+        return Collections.singletonList(EngineIndexService.getSystemIndexDescriptor());
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/GetEngineAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/GetEngineAction.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.entsearch.engine.action;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.entsearch.engine.Engine;
+
+import java.io.IOException;
+
+import static org.elasticsearch.action.ValidateActions.addValidationError;
+
+public class GetEngineAction extends ActionType<GetEngineAction.Response> {
+
+    public static final GetEngineAction INSTANCE = new GetEngineAction();
+    public static final String NAME = "cluster:admin/engine/get";
+
+    private GetEngineAction() {
+        super(NAME, GetEngineAction.Response::new);
+    }
+
+    public static class Request extends ActionRequest {
+
+        private final String engineId;
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            this.engineId = in.readString();
+        }
+
+        @Override
+        public ActionRequestValidationException validate() {
+            ActionRequestValidationException validationException = null;
+
+            if (engineId == null || engineId.isEmpty()) {
+                validationException = addValidationError("engineId missing", validationException);
+            }
+
+            return validationException;
+        }
+
+        public Request(String engineId) {
+            this.engineId = engineId;
+        }
+
+        public String getEngineId() {
+            return engineId;
+        }
+    }
+
+    public static class Response extends ActionResponse implements ToXContentObject {
+
+        private final Engine engine;
+
+        public Response(StreamInput in) throws IOException {
+            super(in);
+            this.engine = new Engine(in);
+        }
+
+        public Response(Engine engine) {
+            this.engine = engine;
+        }
+
+        public Response(String engineId, String[] indices, String analyticsCollectionName, long updatedAt) {
+            this.engine = new Engine(engineId, indices, analyticsCollectionName, updatedAt);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            engine.writeTo(out);
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            return engine.toXContent(builder, params);
+        }
+
+    }
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/RestGetEngineAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/RestGetEngineAction.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.entsearch.engine.action;
+
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestToXContentListener;
+
+import java.util.List;
+
+import static org.elasticsearch.rest.RestRequest.Method.GET;
+
+public class RestGetEngineAction extends BaseRestHandler {
+    public static final String ENDPOINT = "_engine";
+
+    @Override
+    public String getName() {
+        return "get_engine_action";
+    }
+
+    @Override
+    public List<Route> routes() {
+        return List.of(new Route(GET, "/" + ENDPOINT + "/{engine_id}"));
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) {
+        GetEngineAction.Request request = new GetEngineAction.Request(restRequest.param("engine_id"));
+        return channel -> client.execute(GetEngineAction.INSTANCE, request, new RestToXContentListener<>(channel));
+    }
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/RestGetEngineAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/RestGetEngineAction.java
@@ -15,9 +15,9 @@ import org.elasticsearch.rest.action.RestToXContentListener;
 import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
+import static org.elasticsearch.xpack.entsearch.EnterpriseSearch.ENDPOINT;
 
 public class RestGetEngineAction extends BaseRestHandler {
-    public static final String ENDPOINT = "_engine";
 
     @Override
     public String getName() {

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/RestPutEngineAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/RestPutEngineAction.java
@@ -16,10 +16,9 @@ import java.io.IOException;
 import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.PUT;
+import static org.elasticsearch.xpack.entsearch.EnterpriseSearch.ENDPOINT;
 
 public class RestPutEngineAction extends BaseRestHandler {
-
-    public static final String ENDPOINT = "_engine";
 
     @Override
     public String getName() {

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/TransportGetEngineAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/TransportGetEngineAction.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.entsearch.engine.action;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.entsearch.engine.Engine;
+import org.elasticsearch.xpack.entsearch.engine.EngineIndexService;
+
+public class TransportGetEngineAction extends HandledTransportAction<GetEngineAction.Request, GetEngineAction.Response> {
+
+    private final EngineIndexService engineIndexService;
+
+    @Inject
+    public TransportGetEngineAction(TransportService transportService, ActionFilters actionFilters, EngineIndexService engineIndexService) {
+        super(GetEngineAction.NAME, transportService, actionFilters, GetEngineAction.Request::new);
+        this.engineIndexService = engineIndexService;
+    }
+
+    @Override
+    protected void doExecute(Task task, GetEngineAction.Request request, ActionListener<GetEngineAction.Response> listener) {
+        engineIndexService.getEngine(request.getEngineId(), new ActionListener<>() {
+            @Override
+            public void onResponse(Engine engine) {
+                listener.onResponse(new GetEngineAction.Response(engine));
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                listener.onFailure(e);
+            }
+        });
+    }
+
+}


### PR DESCRIPTION
Adds a GET Engine API call to the Enterprise Search Engines module. 

To test this: 
1. Enable the feature flag `xpack.ent-search.enabled=true` and ensure all required licensing and authentication is set. 
2. Create an Engine. Using the PUT API (outside this PR) execute a call to upsert the engine. This will automatically create the required system index and alias. Example: 
```
curl --location --request PUT 'http://localhost:9200/_engine/puggles' \
--<credentials>
--header 'Content-Type: application/json' \
--data-raw '{
    "indices": ["test1", "test2"]
}'
```

3. Get the Engine. Example: 
```
curl --location --request GET 'http://localhost:9200/_engine/puggles' \
--<credentials>
--header 'Content-Type: application/json'
```
