### PR TITLE
Alternative using new method to create mappings in testDeprecatedBoost()

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/80_dense_vector_indexed_by_default.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/80_dense_vector_indexed_by_default.yml
@@ -28,7 +28,6 @@ setup:
             vector:
               type: dense_vector
               dims: 5
-              index: true
               similarity: cosine
 
 ---
@@ -61,7 +60,6 @@ setup:
             vector:
               type: dense_vector
               dims: 5
-              index: true
               similarity: dot_product
               index_options:
                 type: hnsw

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -132,7 +132,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
             super(name);
             this.indexVersionCreated = indexVersionCreated;
             final boolean indexedByDefault = indexVersionCreated.onOrAfter(INDEXED_BY_DEFAULT_INDEX_VERSION);
-            this.indexed = Parameter.indexParam(m -> toType(m).indexed, indexedByDefault).alwaysSerialize();
+            this.indexed = Parameter.indexParam(m -> toType(m).indexed, indexedByDefault);
             this.similarity = Parameter.enumParam(
                 "similarity",
                 false,

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
@@ -74,32 +74,23 @@ public class DenseVectorFieldMapperTests extends MapperTestCase {
 
     @Override
     protected void minimalMapping(XContentBuilder b) throws IOException {
-        b.field("type", "dense_vector").field("dims", 4);
-        if (elementType != ElementType.FLOAT) {
-            b.field("element_type", elementType.toString());
-        }
-        if (indexed) {
-            b.field("similarity", "dot_product");
-            if (indexOptionsSet) {
-                b.startObject("index_options");
-                b.field("type", "hnsw");
-                b.field("m", 5);
-                b.field("ef_construction", 50);
-                b.endObject();
-            }
-        } else {
-            b.field("index", indexed);
-        }
+        createMapping(b, true);
     }
 
     @Override
     protected void deprecatedBoostMapping(XContentBuilder b) throws IOException {
+        createMapping(b, false);
+    }
+
+    private void createMapping(XContentBuilder b, boolean defaultIndexValue) throws IOException {
         b.field("type", "dense_vector").field("dims", 4);
         if (elementType != ElementType.FLOAT) {
             b.field("element_type", elementType.toString());
         }
-        if (indexed) {
+        if (indexed != defaultIndexValue) {
             b.field("index", indexed);
+        }
+        if (indexed) {
             b.field("similarity", "dot_product");
             if (indexOptionsSet) {
                 b.startObject("index_options");

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
@@ -78,8 +78,28 @@ public class DenseVectorFieldMapperTests extends MapperTestCase {
         if (elementType != ElementType.FLOAT) {
             b.field("element_type", elementType.toString());
         }
-        b.field("index", indexed);
         if (indexed) {
+            b.field("similarity", "dot_product");
+            if (indexOptionsSet) {
+                b.startObject("index_options");
+                b.field("type", "hnsw");
+                b.field("m", 5);
+                b.field("ef_construction", 50);
+                b.endObject();
+            }
+        } else {
+            b.field("index", indexed);
+        }
+    }
+
+    @Override
+    protected void deprecatedBoostMapping(XContentBuilder b) throws IOException {
+        b.field("type", "dense_vector").field("dims", 4);
+        if (elementType != ElementType.FLOAT) {
+            b.field("element_type", elementType.toString());
+        }
+        if (indexed) {
+            b.field("index", indexed);
             b.field("similarity", "dot_product");
             if (indexOptionsSet) {
                 b.startObject("index_options");

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
@@ -477,7 +477,7 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
     public final void testDeprecatedBoost() throws IOException {
         try {
             createMapperService(IndexVersion.V_7_10_0, fieldMapping(b -> {
-                minimalMapping(b);
+                deprecatedBoostMapping(b);
                 b.field("boost", 2.0);
             }));
             String[] warnings = Strings.concatStringArrays(
@@ -499,6 +499,10 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
         assertThat(e.getMessage(), anyOf(containsString("Unknown parameter [boost]"), containsString("[boost : 2.0]")));
 
         assertParseMinimalWarnings();
+    }
+
+    protected void deprecatedBoostMapping(XContentBuilder b) throws IOException {
+        minimalMapping(b);
     }
 
     /**


### PR DESCRIPTION
Alternative implementation for https://github.com/elastic/elasticsearch/pull/98268 that uses a new method to create mappings for testDeprecatedBoost().

The downside I see for this approach is that it's convenient to see the `index` mapping param all the time as users might not be aware that it changed default value.