### PR TITLE
PoC DO NOT MERGE - Use root object for storing field inference

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/RestUpdateByQueryAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/RestUpdateByQueryAction.java
@@ -71,6 +71,8 @@ public class RestUpdateByQueryAction extends AbstractBulkByQueryRestHandler<Upda
         consumers.put("script", o -> internal.setScript(Script.parse(o)));
         consumers.put("max_docs", s -> setMaxDocsValidateIdentical(internal, ((Number) s).intValue()));
 
+        // TODO There surely must be a better way of doing this
+        request.params().put("_source_includes", "*");
         parseInternalRequest(internal, request, namedWriteableRegistry, consumers);
 
         internal.setPipeline(request.param("pipeline"));

--- a/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
@@ -106,12 +106,25 @@ public class RootObjectMapper extends ObjectMapper {
 
         @Override
         public RootObjectMapper build(MapperBuilderContext context) {
+            // Check whether we should add field inference mapper
+            // TODO Find a better place for doing this
+            Map<String, Mapper> mappers = buildMappers(context);
+            boolean hasInference = mappers.values()
+                .stream()
+                .anyMatch(mapper -> mapper.typeName().equals(SemanticTextFieldMapper.CONTENT_TYPE));
+
+            if (hasInference) {
+                SemanticTextInferenceFieldMapper semanticTextInferenceFieldMapper = new SemanticTextInferenceFieldMapper.Builder().build(
+                    context
+                );
+                mappers.put(semanticTextInferenceFieldMapper.simpleName(), semanticTextInferenceFieldMapper);
+            }
             return new RootObjectMapper(
                 name,
                 enabled,
                 subobjects,
                 dynamic,
-                buildMappers(context),
+                mappers,
                 runtimeFields,
                 dynamicDateTimeFormatters,
                 dynamicTemplates,

--- a/server/src/main/java/org/elasticsearch/index/mapper/SemanticTextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SemanticTextFieldMapper.java
@@ -146,42 +146,12 @@ public class SemanticTextFieldMapper extends FieldMapper {
     @Override
     public void parse(DocumentParserContext context) throws IOException {
 
-        if (context.parser().currentToken() != XContentParser.Token.START_OBJECT) {
+        if (context.parser().currentToken() != XContentParser.Token.VALUE_STRING) {
             throw new IllegalArgumentException(
-                "[semantic_text] fields must be a json object, expected a START_OBJECT but got: " + context.parser().currentToken()
+                "[semantic_text] fields must be a text value but got: " + context.parser().currentToken()
             );
         }
-
-        boolean textFound = false;
-        boolean inferenceFound = false;
-        for (XContentParser.Token token = context.parser().nextToken(); token != XContentParser.Token.END_OBJECT; token = context.parser()
-            .nextToken()) {
-            if (token != XContentParser.Token.FIELD_NAME) {
-                throw new IllegalArgumentException("[semantic_text] fields expect an object with field names, found " + token);
-            }
-
-            String fieldName = context.parser().currentName();
-            XContentParser.Token valueToken = context.parser().nextToken();
-            switch (fieldName) {
-                case TEXT_SUBFIELD_NAME:
-                    context.doc().add(new StringField(name() + TEXT_SUBFIELD_NAME, context.parser().textOrNull(), Field.Store.NO));
-                    textFound = true;
-                    break;
-                case SPARSE_VECTOR_SUBFIELD_NAME:
-                    sparseVectorFieldMapper.parse(context);
-                    inferenceFound = true;
-                    break;
-                default:
-                    throw new IllegalArgumentException("Unexpected subfield value: " + fieldName);
-            }
-        }
-
-        if (textFound == false) {
-            throw new IllegalArgumentException("[semantic_text] value does not contain [" + TEXT_SUBFIELD_NAME + "] subfield");
-        }
-        if (inferenceFound == false) {
-            throw new IllegalArgumentException("[semantic_text] value does not contain [" + SPARSE_VECTOR_SUBFIELD_NAME + "] subfield");
-        }
+        context.doc().add(new StringField(name(), context.parser().textOrNull(), Field.Store.NO));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/SemanticTextInferenceFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SemanticTextInferenceFieldMapper.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.search.Query;
+import org.elasticsearch.index.mapper.vectors.SparseVectorFieldMapper;
+import org.elasticsearch.index.mapper.vectors.SparseVectorFieldMapper.SparseVectorFieldType;
+import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class SemanticTextInferenceFieldMapper extends FieldMapper {
+
+    public static final String CONTENT_TYPE = "semantic_text_inference";
+
+    public static final String FIELD_NAME = "_semantic_text_inference";
+    public static final String SPARSE_VECTOR_SUBFIELD_NAME = TaskType.SPARSE_EMBEDDING.toString();
+
+    private static SemanticTextInferenceFieldMapper toType(FieldMapper in) {
+        return (SemanticTextInferenceFieldMapper) in;
+    }
+
+    public static class Builder extends FieldMapper.Builder {
+
+        private final Parameter<Map<String, String>> meta = Parameter.metaParam();
+
+        public Builder() {
+            super(FIELD_NAME);
+        }
+
+        @Override
+        protected Parameter<?>[] getParameters() {
+            return new Parameter<?>[] { meta };
+        }
+
+        private SemanticTextInferenceFieldType buildFieldType(MapperBuilderContext context) {
+            return new SemanticTextInferenceFieldType(context.buildFullName(name), meta.getValue());
+        }
+
+        @Override
+        public SemanticTextInferenceFieldMapper build(MapperBuilderContext context) {
+            return new SemanticTextInferenceFieldMapper(name(), new SemanticTextInferenceFieldType(name(), meta.getValue()), copyTo, this);
+        }
+    }
+
+    public static final TypeParser PARSER = new TypeParser((n, c) -> new Builder(), notInMultiFields(CONTENT_TYPE));
+
+    public static class SemanticTextInferenceFieldType extends SimpleMappedFieldType {
+
+        private SparseVectorFieldType sparseVectorFieldType;
+
+        public SemanticTextInferenceFieldType(String name, Map<String, String> meta) {
+            super(name, true, false, false, TextSearchInfo.NONE, meta);
+        }
+
+        public SparseVectorFieldType getSparseVectorFieldType() {
+            return this.sparseVectorFieldType;
+        }
+
+        @Override
+        public String typeName() {
+            return CONTENT_TYPE;
+        }
+
+        @Override
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
+            return SourceValueFetcher.identity(name(), context, format);
+        }
+
+        @Override
+        public Query termQuery(Object value, SearchExecutionContext context) {
+            return sparseVectorFieldType.termQuery(value, context);
+        }
+    }
+
+    private SemanticTextInferenceFieldMapper(String simpleName, MappedFieldType mappedFieldType, CopyTo copyTo, Builder builder) {
+        super(simpleName, mappedFieldType, MultiFields.empty(), copyTo);
+    }
+
+    @Override
+    public FieldMapper.Builder getMergeBuilder() {
+        return new Builder().init(this);
+    }
+
+    @Override
+    public void parse(DocumentParserContext context) throws IOException {
+
+        if (context.parser().currentToken() != XContentParser.Token.START_OBJECT) {
+            throw new IllegalArgumentException(
+                "[_semantic_text_inference] fields must be a json object, expected a START_OBJECT but got: "
+                    + context.parser().currentToken()
+            );
+        }
+
+        MapperBuilderContext mapperBuilderContext = new MapperBuilderContext(FIELD_NAME, false, false);
+
+        // TODO Can we validate that semantic text fields have actual text values?
+        for (XContentParser.Token token = context.parser().nextToken(); token != XContentParser.Token.END_OBJECT; token = context.parser()
+            .nextToken()) {
+            if (token != XContentParser.Token.FIELD_NAME) {
+                throw new IllegalArgumentException("[semantic_text] fields expect an object with field names, found " + token);
+            }
+
+            String fieldName = context.parser().currentName();
+
+            Mapper mapper = context.getMapper(fieldName);
+            if (SemanticTextFieldMapper.CONTENT_TYPE.equals(mapper.typeName()) == false) {
+                throw new IllegalArgumentException(
+                    "Found [" + fieldName + "] in inference values, but it is not registered as a semantic_text field type"
+                );
+            }
+
+            context.parser().nextToken();
+            SparseVectorFieldMapper sparseVectorFieldMapper = new SparseVectorFieldMapper.Builder(fieldName).build(mapperBuilderContext);
+            sparseVectorFieldMapper.parse(context);
+        }
+    }
+
+    @Override
+    protected void parseCreateField(DocumentParserContext context) {
+        throw new AssertionError("parse is implemented directly");
+    }
+
+    @Override
+    protected String contentType() {
+        return CONTENT_TYPE;
+    }
+
+    @Override
+    public SemanticTextInferenceFieldType fieldType() {
+        return (SemanticTextInferenceFieldType) super.fieldType();
+    }
+}

--- a/server/src/main/java/org/elasticsearch/indices/IndicesModule.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesModule.java
@@ -56,6 +56,7 @@ import org.elasticsearch.index.mapper.RangeType;
 import org.elasticsearch.index.mapper.RoutingFieldMapper;
 import org.elasticsearch.index.mapper.RuntimeField;
 import org.elasticsearch.index.mapper.SemanticTextFieldMapper;
+import org.elasticsearch.index.mapper.SemanticTextInferenceFieldMapper;
 import org.elasticsearch.index.mapper.SeqNoFieldMapper;
 import org.elasticsearch.index.mapper.SourceFieldMapper;
 import org.elasticsearch.index.mapper.TextFieldMapper;
@@ -199,6 +200,7 @@ public class IndicesModule extends AbstractModule {
         mappers.put(DenseVectorFieldMapper.CONTENT_TYPE, DenseVectorFieldMapper.PARSER);
         mappers.put(SparseVectorFieldMapper.CONTENT_TYPE, SparseVectorFieldMapper.PARSER);
         mappers.put(SemanticTextFieldMapper.CONTENT_TYPE, SemanticTextFieldMapper.PARSER);
+        mappers.put(SemanticTextInferenceFieldMapper.CONTENT_TYPE, SemanticTextInferenceFieldMapper.PARSER);
 
         for (MapperPlugin mapperPlugin : mapperPlugins) {
             for (Map.Entry<String, Mapper.TypeParser> entry : mapperPlugin.getMappers().entrySet()) {

--- a/server/src/main/java/org/elasticsearch/ingest/FieldInferenceBulkRequestPreprocessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/FieldInferenceBulkRequestPreprocessor.java
@@ -8,6 +8,8 @@
 
 package org.elasticsearch.ingest;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.index.IndexRequest;
@@ -33,6 +35,7 @@ import java.util.function.Supplier;
 
 public class FieldInferenceBulkRequestPreprocessor extends AbstractBulkRequestPreprocessor {
 
+    private static final Logger logger = LogManager.getLogger(FieldInferenceBulkRequestPreprocessor.class);
     public static final String SEMANTIC_TEXT_ORIGIN = "semantic_text";
 
     private final IndicesService indicesService;
@@ -99,11 +102,6 @@ public class FieldInferenceBulkRequestPreprocessor extends AbstractBulkRequestPr
     }
 
     private boolean fieldNeedsInference(IndexRequest indexRequest, String fieldName, Object fieldValue) {
-
-        if (fieldValue instanceof String == false) {
-            return false;
-        }
-
         return getModelForField(indexRequest, fieldName) != null;
     }
 
@@ -147,13 +145,17 @@ public class FieldInferenceBulkRequestPreprocessor extends AbstractBulkRequestPr
         String fieldName = fieldNames.get(0);
         List<String> nextFieldNames = fieldNames.subList(1, fieldNames.size());
         final String fieldValue = ingestDocument.getFieldValue(fieldName, String.class);
-        if (fieldValue == null) {
+        Object existingInference = ingestDocument.getFieldValue(SemanticTextInferenceFieldMapper.FIELD_NAME + "." + fieldName, Object.class, true);
+        if (fieldValue == null || existingInference != null) {
             // Run inference for next field
+            logger.info("Skipping inference for field [" + fieldName + "]");
             runInferenceForFields(indexRequest, nextFieldNames, ref, position, ingestDocument, onFailure);
+            return;
         }
 
         String modelForField = getModelForField(indexRequest, fieldName);
         assert modelForField != null : "Field " + fieldName + " has no model associated in mappings";
+        logger.info("Calculating inference for field [" + fieldName + "]");
 
         // TODO Hardcoding task type, how to get that from model ID?
         InferenceAction.Request inferenceRequest = new InferenceAction.Request(

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchSourceContext.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchSourceContext.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.mapper.SemanticTextInferenceFieldMapper;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.search.lookup.SourceFilter;
 import org.elasticsearch.xcontent.ParseField;
@@ -124,7 +125,8 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
         if (fetchSource != null || sourceIncludes != null || sourceExcludes != null) {
             return FetchSourceContext.of(fetchSource == null || fetchSource, sourceIncludes, sourceExcludes);
         }
-        return null;
+
+        return FetchSourceContext.of(true, null, new String[]{SemanticTextInferenceFieldMapper.FIELD_NAME});
     }
 
     public static FetchSourceContext fromXContent(XContentParser parser) throws IOException {


### PR DESCRIPTION
PoC demoed in GenAI meeting 01/11/2023.

Modifies https://github.com/carlosdelest/elasticsearch/pull/9 by creating a root level object for storing inference results.

It also adds a crude source exclude mechanism so the root field is hidden from the user when source fetching is not specified.

For the following index:

```json
PUT test-semantic
{
    "mappings": {
        "properties": {
            "infer_field": {
                "type": "semantic_text",
                "model_id": "my-elser-model"
            },
            "non_infer_field": {
                "type": "text"
            },
            "another_infer_field": {
                "type": "semantic_text",
                "model_id": "my-elser-model"
            }
        }
    }
}
```

A document ingestion like:

```json
PUT test-semantic/_doc/doc1
{
    "infer_field": "these are not the droids you're looking for",
    "non_infer_field": "he can go about his business",
    "another_infer_field": "move along"
}
```

will look like this once ingested:

```json
GET test-semantic/_doc/doc1?_source_includes=*
{
  "_index": "test-semantic",
  "_id": "doc1",
  "_version": 1,
  "_seq_no": 0,
  "_primary_term": 1,
  "found": true,
  "_source": {
    "_semantic_text_inference": {
      "infer_field": {
        "lucas": 0.05212344,
        "ty": 0.041213956,
        "dragon": 0.50991,
        "type": 0.23241979,
        "dr": 1.9312073,
        "##o": 0.2797593,
        "these": 1.1422911,
        "robot": 0.3821148
      },
      "another_infer_field": {
        "play": 0.32950363,
        "hum": 0.003634397,
        "tempo": 0.15531318,
        "anger": 0.028992891,
        "soon": 0.37861174,
        "crawl": 0.10688804,
        "road": 0.10052208,
        "action": 0.18112859,
        "talk": 0.48378038,
        "up": 0.17651497,
        "moving": 1.8461642
      }
    },
    "infer_field": "these are not the droids you're looking for",
    "another_infer_field": "move along",
    "non_infer_field": "he can go about his business"
  }
}
```

Root level field is hidden automatically unless source fetching is specified:

```json
GET test-semantic/_doc/doc1
{
  "_index": "test-semantic",
  "_id": "doc1",
  "_version": 1,
  "_seq_no": 0,
  "_primary_term": 1,
  "found": true,
  "_source": {
    "infer_field": "these are not the droids you're looking for",
    "another_infer_field": "move along",
    "non_infer_field": "he can go about his business"
  }
}
```

