### PR TITLE
PoC DO NOT MERGE - Semantic Query

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/RestUpdateByQueryAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/RestUpdateByQueryAction.java
@@ -71,6 +71,8 @@ public class RestUpdateByQueryAction extends AbstractBulkByQueryRestHandler<Upda
         consumers.put("script", o -> internal.setScript(Script.parse(o)));
         consumers.put("max_docs", s -> setMaxDocsValidateIdentical(internal, ((Number) s).intValue()));
 
+        // TODO There surely must be a better way of doing this
+        request.params().put("_source_includes", "*");
         parseInternalRequest(internal, request, namedWriteableRegistry, consumers);
 
         internal.setPipeline(request.param("pipeline"));

--- a/server/src/main/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhase.java
+++ b/server/src/main/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhase.java
@@ -165,7 +165,7 @@ final class CanMatchPreFilterSearchPhase extends SearchPhase {
                 continue;
             }
             boolean canMatch = true;
-            CoordinatorRewriteContext coordinatorRewriteContext = coordinatorRewriteContextProvider.getCoordinatorRewriteContext(
+            CoordinatorRewriteContext coordinatorRewriteContext = coordinatorRewriteContextProvider.getCoordinatorRewriteContextForIndex(
                 request.shardId().getIndex()
             );
             if (coordinatorRewriteContext != null) {

--- a/server/src/main/java/org/elasticsearch/action/search/CoordinatorQueryRewriteSearchPhase.java
+++ b/server/src/main/java/org/elasticsearch/action/search/CoordinatorQueryRewriteSearchPhase.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.search;
+
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.routing.GroupShardsIterator;
+import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.mapper.MappingLookup;
+import org.elasticsearch.index.query.CoordinatorRewriteContext;
+import org.elasticsearch.index.query.CoordinatorRewriteContextProvider;
+import org.elasticsearch.index.query.Rewriteable;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executor;
+
+import static org.elasticsearch.core.Strings.format;
+
+/**
+ * This search phase can be used as an initial search phase to pre-filter search shards based on query rewriting.
+ * The queries are rewritten against the shards and based on the rewrite result shards might be able to be excluded
+ * from the search. The extra round trip to the search shards is very cheap and is not subject to rejections
+ * which allows to fan out to more shards at the same time without running into rejections even if we are hitting a
+ * large portion of the clusters indices.
+ * This phase can also be used to pre-sort shards based on min/max values in each shard of the provided primary sort.
+ * When the query primary sort is perform on a field, this phase extracts the min/max value in each shard and
+ * sort them according to the provided order. This can be useful for instance to ensure that shards that contain recent
+ * data are executed first when sorting by descending timestamp.
+ */
+final class CoordinatorQueryRewriteSearchPhase extends SearchPhase {
+
+    private final Logger logger;
+    private final SearchRequest request;
+    private final GroupShardsIterator<SearchShardIterator> shardsIts;
+    private final ActionListener<SearchRequest> listener;
+
+    private final CoordinatorRewriteContextProvider coordinatorRewriteContextProvider;
+
+    private final IndicesService indicesService;
+
+    private final Executor executor;
+
+    CoordinatorQueryRewriteSearchPhase(
+        Logger logger,
+        SearchRequest request,
+        GroupShardsIterator<SearchShardIterator> shardsIts,
+        Executor executor,
+        IndicesService indicesService,
+        CoordinatorRewriteContextProvider coordinatorRewriteContextProvider,
+        ActionListener<SearchRequest> listener
+    ) {
+        super("coordinator_rewrite");
+
+        this.logger = logger;
+        this.request = request;
+        this.executor = executor;
+        this.listener = listener;
+        this.shardsIts = shardsIts;
+        this.coordinatorRewriteContextProvider = coordinatorRewriteContextProvider;
+        this.indicesService = indicesService;
+    }
+
+    private static boolean assertSearchCoordinationThread() {
+        return ThreadPool.assertCurrentThreadPool(ThreadPool.Names.SEARCH_COORDINATION);
+    }
+
+    @Override
+    public void run() throws IOException {
+        assert assertSearchCoordinationThread();
+        runCoordinatorRewritePhase();
+    }
+
+    // tries to pre-filter shards based on information that's available to the coordinator
+    // without having to reach out to the actual shards
+    private void runCoordinatorRewritePhase() {
+        // TODO: the index filter (i.e, `_index:patten`) should be prefiltered on the coordinator
+        assert assertSearchCoordinationThread();
+        final List<SearchShardIterator> matchedShardLevelRequests = new ArrayList<>();
+        Map<String, Set<String>> fieldModelIds = new HashMap<>();
+        for (SearchShardIterator searchShardIterator : shardsIts) {
+            Index index = searchShardIterator.shardId().getIndex();
+            MappingLookup mappingLookup = indicesService.indexService(index).mapperService().mappingLookup();
+            mappingLookup.modelsForFields().forEach((k, v) -> {
+                Set<String> modelIds = fieldModelIds.computeIfAbsent(k, value -> new HashSet<String>());
+                modelIds.add(v);
+            });
+        }
+
+        CoordinatorRewriteContext coordinatorRewriteContext = coordinatorRewriteContextProvider.getCoordinatorRewriteContextForModels(
+            fieldModelIds
+        );
+        Rewriteable.rewriteAndFetch(request, coordinatorRewriteContext, listener);
+    }
+
+    @Override
+    public void start() {
+        // Note that the search is failed when this task is rejected by the executor
+        executor.execute(new AbstractRunnable() {
+            @Override
+            public void onFailure(Exception e) {
+                if (logger.isDebugEnabled()) {
+                    logger.debug(() -> format("Failed to execute [%s] while running [%s] phase", request, getName()), e);
+                }
+                listener.onFailure(new SearchPhaseExecutionException(getName(), e.getMessage(), e.getCause(), ShardSearchFailure.EMPTY_ARRAY));
+            }
+
+            @Override
+            protected void doRun() throws IOException {
+                CoordinatorQueryRewriteSearchPhase.this.run();
+            }
+        });
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/search/TransportOpenPointInTimeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportOpenPointInTimeAction.java
@@ -123,6 +123,7 @@ public class TransportOpenPointInTimeAction extends HandledTransportAction<OpenP
             Map<String, AliasFilter> aliasFilter,
             Map<String, Float> concreteIndexBoosts,
             boolean preFilter,
+            boolean runCoordinatorPhase,
             ThreadPool threadPool,
             SearchResponse.Clusters clusters
         ) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
@@ -120,6 +120,10 @@ final class FieldTypeLookup {
         return this.fieldToInferenceModels.get(fieldName);
     }
 
+    Map<String, String> modelsForFields() {
+        return this.fieldToInferenceModels;
+    }
+
     /**
      * Returns the mapped field type for the given field name.
      */

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
@@ -495,4 +495,8 @@ public final class MappingLookup {
     public String modelForField(String fieldName) {
         return fieldTypeLookup.modelForField(fieldName);
     }
+
+    public Map<String, String> modelsForFields() {
+        return fieldTypeLookup.modelsForFields();
+    }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/SemanticTextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SemanticTextFieldMapper.java
@@ -80,12 +80,13 @@ public class SemanticTextFieldMapper extends FieldMapper {
 
     public static class SemanticTextFieldType extends SimpleMappedFieldType {
 
-        private SparseVectorFieldType sparseVectorFieldType;
+        private final SparseVectorFieldType sparseVectorFieldType;
 
         private final String modelId;
 
         public SemanticTextFieldType(String name, String modelId, Map<String, String> meta) {
             super(name, true, false, false, TextSearchInfo.NONE, meta);
+            this.sparseVectorFieldType = new SparseVectorFieldType(name + "." + SPARSE_VECTOR_SUBFIELD_NAME, meta);
             this.modelId = modelId;
         }
 

--- a/server/src/main/java/org/elasticsearch/index/query/CoordinatorRewriteContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/CoordinatorRewriteContext.java
@@ -17,6 +17,8 @@ import org.elasticsearch.index.shard.IndexLongFieldRange;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 
 import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.LongSupplier;
 
 /**
@@ -27,8 +29,11 @@ import java.util.function.LongSupplier;
  * don't hold queried data. See IndexMetadata#getTimestampRange() for more details
  */
 public class CoordinatorRewriteContext extends QueryRewriteContext {
+    @Nullable
     private final IndexLongFieldRange indexLongFieldRange;
+    @Nullable
     private final DateFieldMapper.DateFieldType timestampFieldType;
+    private final Map<String, Set<String>> fieldNamesToInferenceModel;
 
     public CoordinatorRewriteContext(
         XContentParserConfiguration parserConfig,
@@ -55,6 +60,34 @@ public class CoordinatorRewriteContext extends QueryRewriteContext {
         );
         this.indexLongFieldRange = indexLongFieldRange;
         this.timestampFieldType = timestampFieldType;
+        this.fieldNamesToInferenceModel = Map.of();
+    }
+
+    public CoordinatorRewriteContext(
+        XContentParserConfiguration parserConfig,
+        Client client,
+        LongSupplier nowInMillis,
+        Map<String, Set<String>> fieldNamesToInferenceModel
+    ) {
+        super(
+            parserConfig,
+            client,
+            nowInMillis,
+            null,
+            MappingLookup.EMPTY,
+            Collections.emptyMap(),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+        this.indexLongFieldRange = null;
+        this.timestampFieldType = null;
+        this.fieldNamesToInferenceModel = fieldNamesToInferenceModel;
     }
 
     long getMinTimestamp() {
@@ -81,5 +114,10 @@ public class CoordinatorRewriteContext extends QueryRewriteContext {
     @Override
     public CoordinatorRewriteContext convertToCoordinatorRewriteContext() {
         return this;
+    }
+
+    @Nullable
+    public Set<String> inferenceModelsForFieldName(String fieldName) {
+        return fieldNamesToInferenceModel.get(fieldName);
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/query/CoordinatorRewriteContextProvider.java
+++ b/server/src/main/java/org/elasticsearch/index/query/CoordinatorRewriteContextProvider.java
@@ -13,9 +13,12 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.mapper.DateFieldMapper;
+import org.elasticsearch.index.mapper.StringFieldType;
 import org.elasticsearch.index.shard.IndexLongFieldRange;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
@@ -42,7 +45,7 @@ public class CoordinatorRewriteContextProvider {
     }
 
     @Nullable
-    public CoordinatorRewriteContext getCoordinatorRewriteContext(Index index) {
+    public CoordinatorRewriteContext getCoordinatorRewriteContextForIndex(Index index) {
         var clusterState = clusterStateSupplier.get();
         var indexMetadata = clusterState.metadata().index(index);
 
@@ -62,5 +65,10 @@ public class CoordinatorRewriteContextProvider {
         }
 
         return new CoordinatorRewriteContext(parserConfig, client, nowInMillis, timestampRange, dateFieldType);
+    }
+
+    @Nullable
+    public CoordinatorRewriteContext getCoordinatorRewriteContextForModels(Map<String, Set<String>> fieldToModelIds) {
+        return new CoordinatorRewriteContext(parserConfig, client, nowInMillis, fieldToModelIds);
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/query/CoordinatorRewriteableQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/CoordinatorRewriteableQueryBuilder.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.query;
+
+// Marker interface for queries that can be
+public interface CoordinatorRewriteableQueryBuilder {
+}

--- a/server/src/main/java/org/elasticsearch/ingest/FieldInferenceBulkRequestPreprocessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/FieldInferenceBulkRequestPreprocessor.java
@@ -145,7 +145,7 @@ public class FieldInferenceBulkRequestPreprocessor extends AbstractBulkRequestPr
         String fieldName = fieldNames.get(0);
         List<String> nextFieldNames = fieldNames.subList(1, fieldNames.size());
         final String fieldValue = ingestDocument.getFieldValue(fieldName, String.class);
-        Object existingInference = ingestDocument.getFieldValue(SemanticTextInferenceFieldMapper.FIELD_NAME + "." + fieldName, Object.class, true);
+        Object existingInference = ingestDocument.getFieldValue(fieldName + "." + SemanticTextFieldMapper.SPARSE_VECTOR_SUBFIELD_NAME, Object.class, true);
         if (fieldValue == null || existingInference != null) {
             // Run inference for next field
             logger.info("Skipping inference for field [" + fieldName + "]");

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -51,6 +51,7 @@ import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.query.CoordinatorRewriteContextProvider;
+import org.elasticsearch.index.query.CoordinatorRewriteableQueryBuilder;
 import org.elasticsearch.index.query.InnerHitContextBuilder;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.MatchNoneQueryBuilder;
@@ -1734,6 +1735,13 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         }
         AggregatorFactories.Builder aggregations = source.aggregations();
         return aggregations == null || aggregations.mustVisitAllDocs() == false;
+    }
+
+    public static boolean canRewriteInCoordinator(SearchSourceBuilder source) {
+        if (source == null) {
+            return false;
+        }
+        return source.subSearches().stream().anyMatch(sqwb -> sqwb.getQueryBuilder() instanceof CoordinatorRewriteableQueryBuilder);
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchSourceContext.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchSourceContext.java
@@ -15,7 +15,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.Nullable;
-import org.elasticsearch.index.mapper.SemanticTextInferenceFieldMapper;
+import org.elasticsearch.index.mapper.SemanticTextFieldMapper;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.search.lookup.SourceFilter;
 import org.elasticsearch.xcontent.ParseField;
@@ -126,7 +126,7 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
             return FetchSourceContext.of(fetchSource == null || fetchSource, sourceIncludes, sourceExcludes);
         }
 
-        return FetchSourceContext.of(true, null, new String[]{SemanticTextInferenceFieldMapper.FIELD_NAME});
+        return FetchSourceContext.of(true, null, new String[]{"*." + SemanticTextFieldMapper.SPARSE_VECTOR_SUBFIELD_NAME});
     }
 
     public static FetchSourceContext fromXContent(XContentParser parser) throws IOException {

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchSourceContext.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchSourceContext.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.mapper.SemanticTextInferenceFieldMapper;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.search.lookup.SourceFilter;
 import org.elasticsearch.xcontent.ParseField;
@@ -124,7 +125,8 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
         if (fetchSource != null || sourceIncludes != null || sourceExcludes != null) {
             return FetchSourceContext.of(fetchSource == null || fetchSource, sourceIncludes, sourceExcludes);
         }
-        return null;
+
+        return FetchSourceContext.of(true, null, new String[]{SemanticTextInferenceFieldMapper.FIELD_NAME});
     }
 
     public static FetchSourceContext fromXContent(XContentParser parser) throws IOException {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -366,6 +366,7 @@ import org.elasticsearch.xpack.ml.process.MlControllerHolder;
 import org.elasticsearch.xpack.ml.process.MlMemoryTracker;
 import org.elasticsearch.xpack.ml.process.NativeController;
 import org.elasticsearch.xpack.ml.process.NativeStorageProvider;
+import org.elasticsearch.xpack.ml.queries.SemanticQueryBuilder;
 import org.elasticsearch.xpack.ml.queries.TextExpansionQueryBuilder;
 import org.elasticsearch.xpack.ml.rest.RestDeleteExpiredDataAction;
 import org.elasticsearch.xpack.ml.rest.RestMlInfoAction;
@@ -1688,6 +1689,11 @@ public class MachineLearning extends Plugin
                 TextExpansionQueryBuilder.NAME,
                 TextExpansionQueryBuilder::new,
                 TextExpansionQueryBuilder::fromXContent
+            ),
+            new QuerySpec<QueryBuilder>(
+                SemanticQueryBuilder.NAME,
+                SemanticQueryBuilder::new,
+                SemanticQueryBuilder::fromXContent
             )
         );
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/queries/SemanticQueryBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/queries/SemanticQueryBuilder.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.xpack.ml.queries;
+
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.SetOnce;
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.inference.InferenceAction;
+import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.mapper.SemanticTextFieldMapper;
+import org.elasticsearch.index.query.AbstractQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.QueryRewriteContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.inference.InferenceResults;
+import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xpack.core.ml.inference.results.TextExpansionResults;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.elasticsearch.TransportVersions.SEMANTIC_TEXT_FIELD_ADDED;
+import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
+import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
+
+public class SemanticQueryBuilder extends AbstractQueryBuilder<SemanticQueryBuilder> {
+
+    public static final String NAME = "semantic_query";
+
+    private final String fieldName;
+    private final String query;
+
+    private static final ParseField QUERY_FIELD = new ParseField("query");
+
+    private SetOnce<InferenceResults> inferenceResultsSupplier;
+
+    public SemanticQueryBuilder(String fieldName, String query) {
+        if (fieldName == null) {
+            throw new IllegalArgumentException("[" + NAME + "] requires a fieldName");
+        }
+        if (query == null) {
+            throw new IllegalArgumentException("[" + NAME + "] requires a query");
+        }
+        this.fieldName = fieldName;
+        this.query = query;
+    }
+
+    public SemanticQueryBuilder(SemanticQueryBuilder other, SetOnce<InferenceResults> inferenceResultsSupplier) {
+        this.fieldName = other.fieldName;
+        this.query = other.query;
+        this.inferenceResultsSupplier = inferenceResultsSupplier;
+    }
+
+    public SemanticQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        this.fieldName = in.readString();
+        this.query = in.readString();
+    }
+
+    @Override
+    protected QueryBuilder doRewrite(QueryRewriteContext queryRewriteContext) throws IOException {
+        if (inferenceResultsSupplier != null) {
+            if (inferenceResultsSupplier.get() == null) {
+                // Inference still not returned
+                return this;
+            }
+            return inferenceResultsToQuery(fieldName, inferenceResultsSupplier.get());
+        }
+
+        String modelName = queryRewriteContext.modelNameForField(fieldName);
+        if (modelName == null) {
+            throw new IllegalArgumentException(
+                "field [" + fieldName + "] is not a " + SemanticTextFieldMapper.CONTENT_TYPE + " field type"
+            );
+
+        }
+        // TODO Hardcoding task type
+        InferenceAction.Request inferenceRequest = new InferenceAction.Request(TaskType.SPARSE_EMBEDDING, modelName, query, Map.of());
+
+        SetOnce<InferenceResults> inferenceResultsSupplier = new SetOnce<>();
+        queryRewriteContext.registerAsyncAction((client, listener) -> {
+            executeAsyncWithOrigin(client, ML_ORIGIN, InferenceAction.INSTANCE, inferenceRequest, ActionListener.wrap(inferenceResponse -> {
+                inferenceResultsSupplier.set(inferenceResponse.getResult());
+            }, listener::onFailure));
+        });
+
+        return new SemanticQueryBuilder(this, inferenceResultsSupplier);
+    }
+
+    private static QueryBuilder inferenceResultsToQuery(String fieldName, InferenceResults inferenceResults) {
+        if (inferenceResults instanceof TextExpansionResults expansionResults) {
+            var boolQuery = QueryBuilders.boolQuery();
+            for (var weightedToken : expansionResults.getWeightedTokens()) {
+                boolQuery.should(QueryBuilders.termQuery(fieldName, weightedToken.token()).boost(weightedToken.weight()));
+            }
+            boolQuery.minimumShouldMatch(1);
+            return boolQuery;
+        } else {
+            throw new IllegalArgumentException(
+                "field [" + fieldName + "] does not use a model that outputs sparse vector inference results"
+            );
+        }
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+
+    @Override
+    public TransportVersion getMinimalSupportedVersion() {
+        return SEMANTIC_TEXT_FIELD_ADDED;
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        if (inferenceResultsSupplier != null) {
+            throw new IllegalStateException("inference supplier must be null, can't serialize suppliers, missing a rewriteAndFetch?");
+        }
+        out.writeString(fieldName);
+    }
+
+    @Override
+    protected void doXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(NAME);
+        builder.startObject(fieldName);
+        boostAndQueryNameToXContent(builder);
+        builder.endObject();
+        builder.endObject();
+    }
+
+    @Override
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
+        throw new IllegalStateException("semantic_query should have been rewritten to another query type");
+    }
+
+    @Override
+    protected boolean doEquals(SemanticQueryBuilder other) {
+        return Objects.equals(fieldName, other.fieldName)
+            && Objects.equals(query, other.query)
+            && Objects.equals(inferenceResultsSupplier, other.inferenceResultsSupplier);
+    }
+
+    @Override
+    protected int doHashCode() {
+        return Objects.hash(fieldName, query, inferenceResultsSupplier);
+    }
+
+    public static SemanticQueryBuilder fromXContent(XContentParser parser) throws IOException {
+        String fieldName = null;
+        String query = null;
+        float boost = AbstractQueryBuilder.DEFAULT_BOOST;
+        String queryName = null;
+        String currentFieldName = null;
+        XContentParser.Token token;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+            } else if (token == XContentParser.Token.START_OBJECT) {
+                throwParsingExceptionOnMultipleFields(NAME, parser.getTokenLocation(), fieldName, currentFieldName);
+                fieldName = currentFieldName;
+                while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+                    if (token == XContentParser.Token.FIELD_NAME) {
+                        currentFieldName = parser.currentName();
+                    } else if (token.isValue()) {
+                        if (QUERY_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                            query = parser.text();
+                        } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                            boost = parser.floatValue();
+                        } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                            queryName = parser.text();
+                        } else {
+                            throw new ParsingException(
+                                parser.getTokenLocation(),
+                                "[" + NAME + "] query does not support [" + currentFieldName + "]"
+                            );
+                        }
+                    } else {
+                        throw new ParsingException(
+                            parser.getTokenLocation(),
+                            "[" + NAME + "] unknown token [" + token + "] after [" + currentFieldName + "]"
+                        );
+                    }
+                }
+            }
+        }
+
+        if (fieldName == null) {
+            throw new ParsingException(parser.getTokenLocation(), "No field name specified for semantic query");
+        }
+
+        if (query == null) {
+            throw new ParsingException(parser.getTokenLocation(), "No query specified for semantic query");
+        }
+
+        SemanticQueryBuilder queryBuilder = new SemanticQueryBuilder(fieldName, query);
+        queryBuilder.queryName(queryName);
+        queryBuilder.boost(boost);
+        return queryBuilder;
+    }
+}


### PR DESCRIPTION
PoC for a `semantic_query` query builder:

```json
GET test-semantic/_search
{
    "query": {
        "semantic_query": {
            "infer_field": {
                "query": "burger"
            }
        }
    }
}
```

Uses a new search phase for performing coordinator level query rewriting.

New information for field to model IDs is added to the coordinator rewrite context so the query can perform the actual inference on rewriting.

You can follow [this gist](https://gist.github.com/carlosdelest/c5d023567ab446679076f1751deaf25b) to test.
