### PR TITLE
semantic text bulk inference integration test

### DIFF
--- a/x-pack/plugin/inference/build.gradle
+++ b/x-pack/plugin/inference/build.gradle
@@ -30,6 +30,7 @@ dependencies {
   compileOnly project(":server")
   compileOnly project(path: xpackModule('core'))
   testImplementation(testArtifact(project(xpackModule('core'))))
+  testImplementation(project(':x-pack:plugin:inference:qa:test-service-plugin'))
   testImplementation project(':modules:reindex')
   clusterPlugins project(':x-pack:plugin:inference:qa:test-service-plugin')
 

--- a/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/AbstractTestInferenceService.java
+++ b/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/AbstractTestInferenceService.java
@@ -28,11 +28,8 @@ import java.util.Map;
 public abstract class AbstractTestInferenceService implements InferenceService {
 
     protected static int stringWeight(String input, int position) {
-        int hashCode = input.hashCode();
-        if (hashCode < 0) {
-            hashCode = -hashCode;
-        }
-        return hashCode + position;
+        // Ensure non-negative and non-zero values for features
+        return Math.abs(input.hashCode()) + 1 + position;
     }
 
     @Override

--- a/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/AbstractTestInferenceService.java
+++ b/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/AbstractTestInferenceService.java
@@ -18,7 +18,6 @@ import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ModelSecrets;
 import org.elasticsearch.inference.SecretSettings;
 import org.elasticsearch.inference.ServiceSettings;
-import org.elasticsearch.inference.SimilarityMeasure;
 import org.elasticsearch.inference.TaskSettings;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xcontent.XContentBuilder;

--- a/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/AbstractTestInferenceService.java
+++ b/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/AbstractTestInferenceService.java
@@ -18,6 +18,7 @@ import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ModelSecrets;
 import org.elasticsearch.inference.SecretSettings;
 import org.elasticsearch.inference.ServiceSettings;
+import org.elasticsearch.inference.SimilarityMeasure;
 import org.elasticsearch.inference.TaskSettings;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -26,11 +27,6 @@ import java.io.IOException;
 import java.util.Map;
 
 public abstract class AbstractTestInferenceService implements InferenceService {
-
-    protected static int stringWeight(String input, int position) {
-        // Ensure non-negative and non-zero values for features
-        return Math.abs(input.hashCode()) + 1 + position;
-    }
 
     @Override
     public TransportVersion getMinimalSupportedVersion() {

--- a/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/TestDenseInferenceServiceExtension.java
+++ b/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/TestDenseInferenceServiceExtension.java
@@ -100,9 +100,7 @@ public class TestDenseInferenceServiceExtension implements InferenceServiceExten
             switch (model.getConfigurations().getTaskType()) {
                 case ANY, TEXT_EMBEDDING -> {
                     ServiceSettings modelServiceSettings = model.getServiceSettings();
-                    listener.onResponse(
-                        makeResults(input, modelServiceSettings.dimensions(), modelServiceSettings.similarity())
-                    );
+                    listener.onResponse(makeResults(input, modelServiceSettings.dimensions(), modelServiceSettings.similarity()));
                 }
                 default -> listener.onFailure(
                     new ElasticsearchStatusException(
@@ -175,7 +173,7 @@ public class TestDenseInferenceServiceExtension implements InferenceServiceExten
         private static double[] generateEmbedding(String input, int dimensions, SimilarityMeasure similarityMeasure) {
             double[] embedding = new double[dimensions];
             for (int j = 0; j < dimensions; j++) {
-                embedding[j] = input.hashCode() + (double)j;
+                embedding[j] = input.hashCode() + (double) j;
             }
 
             return embedding;

--- a/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/TestDenseInferenceServiceExtension.java
+++ b/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/TestDenseInferenceServiceExtension.java
@@ -177,37 +177,8 @@ public class TestDenseInferenceServiceExtension implements InferenceServiceExten
             for (int j = 0; j < dimensions; j++) {
                 embedding[j] = input.hashCode() + (double)j;
             }
-            if (similarityMeasure == SimilarityMeasure.DOT_PRODUCT) {
-                embedding = normalizeVector(embedding);
-            }
 
             return embedding;
-        }
-
-        private static double[] normalizeVector(double[] vector) {
-            double[] normalizedVector = new double[vector.length];
-
-            // Calculate the Euclidean norm of the vector
-            double norm = calculateNorm(vector);
-
-            // Normalize each component of the vector
-            for (int i = 0; i < vector.length; i++) {
-                normalizedVector[i] = vector[i] / norm;
-            }
-
-            return normalizedVector;
-        }
-
-        private static double calculateNorm(double[] vector) {
-            double sumOfSquares = 0.0f;
-
-            // Calculate the sum of squares of each component
-            for (double component : vector) {
-                sumOfSquares += component * component;
-            }
-
-            // Return the square root of the sum of squares
-            return (float) Math.sqrt(sumOfSquares);
         }
     }
 

--- a/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/TestDenseInferenceServiceExtension.java
+++ b/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/TestDenseInferenceServiceExtension.java
@@ -22,6 +22,7 @@ import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.Model;
 import org.elasticsearch.inference.ModelConfigurations;
+import org.elasticsearch.inference.ModelSecrets;
 import org.elasticsearch.inference.ServiceSettings;
 import org.elasticsearch.inference.SimilarityMeasure;
 import org.elasticsearch.inference.TaskType;
@@ -43,8 +44,22 @@ public class TestDenseInferenceServiceExtension implements InferenceServiceExten
         return List.of(TestInferenceService::new);
     }
 
+    public static class TestDenseModel extends Model {
+        public TestDenseModel(String inferenceEntityId, TestDenseInferenceServiceExtension.TestServiceSettings serviceSettings) {
+            super(
+                new ModelConfigurations(
+                    inferenceEntityId,
+                    TaskType.TEXT_EMBEDDING,
+                    TestDenseInferenceServiceExtension.TestInferenceService.NAME,
+                    serviceSettings
+                ),
+                new ModelSecrets(new AbstractTestInferenceService.TestSecretSettings("api_key"))
+            );
+        }
+    }
+
     public static class TestInferenceService extends AbstractTestInferenceService {
-        private static final String NAME = "text_embedding_test_service";
+        public static final String NAME = "text_embedding_test_service";
 
         public TestInferenceService(InferenceServiceFactoryContext context) {}
 
@@ -83,9 +98,12 @@ public class TestDenseInferenceServiceExtension implements InferenceServiceExten
             ActionListener<InferenceServiceResults> listener
         ) {
             switch (model.getConfigurations().getTaskType()) {
-                case ANY, TEXT_EMBEDDING -> listener.onResponse(
-                    makeResults(input, ((TestServiceModel) model).getServiceSettings().dimensions())
-                );
+                case ANY, TEXT_EMBEDDING -> {
+                    ServiceSettings modelServiceSettings = model.getServiceSettings();
+                    listener.onResponse(
+                        makeResults(input, modelServiceSettings.dimensions(), modelServiceSettings.similarity())
+                    );
+                }
                 default -> listener.onFailure(
                     new ElasticsearchStatusException(
                         TaskType.unsupportedTaskTypeErrorMsg(model.getConfigurations().getTaskType(), name()),
@@ -107,9 +125,10 @@ public class TestDenseInferenceServiceExtension implements InferenceServiceExten
             ActionListener<List<ChunkedInferenceServiceResults>> listener
         ) {
             switch (model.getConfigurations().getTaskType()) {
-                case ANY, TEXT_EMBEDDING -> listener.onResponse(
-                    makeChunkedResults(input, ((TestServiceModel) model).getServiceSettings().dimensions())
-                );
+                case ANY, TEXT_EMBEDDING -> {
+                    ServiceSettings modelServiceSettings = model.getServiceSettings();
+                    listener.onResponse(makeChunkedResults(input, modelServiceSettings.dimensions(), modelServiceSettings.similarity()));
+                }
                 default -> listener.onFailure(
                     new ElasticsearchStatusException(
                         TaskType.unsupportedTaskTypeErrorMsg(model.getConfigurations().getTaskType(), name()),
@@ -119,28 +138,30 @@ public class TestDenseInferenceServiceExtension implements InferenceServiceExten
             }
         }
 
-        private TextEmbeddingResults makeResults(List<String> input, int dimensions) {
+        private TextEmbeddingResults makeResults(List<String> input, int dimensions, SimilarityMeasure similarityMeasure) {
             List<TextEmbeddingResults.Embedding> embeddings = new ArrayList<>();
             for (int i = 0; i < input.size(); i++) {
-                List<Float> values = new ArrayList<>();
+                double[] doubleEmbeddings = generateEmbedding(input.get(i), dimensions, similarityMeasure);
+                List<Float> floatEmbeddings = new ArrayList<>(dimensions);
                 for (int j = 0; j < dimensions; j++) {
-                    values.add((float) stringWeight(input.get(i), j));
+                    floatEmbeddings.add((float) doubleEmbeddings[j]);
                 }
-                embeddings.add(new TextEmbeddingResults.Embedding(values));
+                embeddings.add(new TextEmbeddingResults.Embedding(floatEmbeddings));
             }
             return new TextEmbeddingResults(embeddings);
         }
 
-        private List<ChunkedInferenceServiceResults> makeChunkedResults(List<String> input, int dimensions) {
+        private List<ChunkedInferenceServiceResults> makeChunkedResults(
+            List<String> input,
+            int dimensions,
+            SimilarityMeasure similarityMeasure
+        ) {
             var results = new ArrayList<ChunkedInferenceServiceResults>();
             for (int i = 0; i < input.size(); i++) {
-                double[] values = new double[dimensions];
-                for (int j = 0; j < dimensions; j++) {
-                    values[j] = stringWeight(input.get(i), j);
-                }
+                double[] embeddings = generateEmbedding(input.get(i), dimensions, similarityMeasure);
                 results.add(
                     new org.elasticsearch.xpack.core.inference.results.ChunkedTextEmbeddingResults(
-                        List.of(new ChunkedTextEmbeddingResults.EmbeddingChunk(input.get(i), values))
+                        List.of(new ChunkedTextEmbeddingResults.EmbeddingChunk(input.get(i), embeddings))
                     )
                 );
             }
@@ -149,6 +170,44 @@ public class TestDenseInferenceServiceExtension implements InferenceServiceExten
 
         protected ServiceSettings getServiceSettingsFromMap(Map<String, Object> serviceSettingsMap) {
             return TestServiceSettings.fromMap(serviceSettingsMap);
+        }
+
+        private static double[] generateEmbedding(String input, int dimensions, SimilarityMeasure similarityMeasure) {
+            double[] embedding = new double[dimensions];
+            for (int j = 0; j < dimensions; j++) {
+                embedding[j] = input.hashCode() + (double)j;
+            }
+            if (similarityMeasure == SimilarityMeasure.DOT_PRODUCT) {
+                embedding = normalizeVector(embedding);
+            }
+
+            return embedding;
+        }
+
+        private static double[] normalizeVector(double[] vector) {
+            double[] normalizedVector = new double[vector.length];
+
+            // Calculate the Euclidean norm of the vector
+            double norm = calculateNorm(vector);
+
+            // Normalize each component of the vector
+            for (int i = 0; i < vector.length; i++) {
+                normalizedVector[i] = vector[i] / norm;
+            }
+
+            return normalizedVector;
+        }
+
+        private static double calculateNorm(double[] vector) {
+            double sumOfSquares = 0.0f;
+
+            // Calculate the sum of squares of each component
+            for (double component : vector) {
+                sumOfSquares += component * component;
+            }
+
+            // Return the square root of the sum of squares
+            return (float) Math.sqrt(sumOfSquares);
         }
     }
 

--- a/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/TestSparseInferenceServiceExtension.java
+++ b/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/TestSparseInferenceServiceExtension.java
@@ -22,6 +22,7 @@ import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.Model;
 import org.elasticsearch.inference.ModelConfigurations;
+import org.elasticsearch.inference.ModelSecrets;
 import org.elasticsearch.inference.ServiceSettings;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.rest.RestStatus;
@@ -44,8 +45,21 @@ public class TestSparseInferenceServiceExtension implements InferenceServiceExte
         return List.of(TestInferenceService::new);
     }
 
+    public static class TestSparseModel extends Model {
+
+        public TestSparseModel(
+            String inferenceEntityId,
+            TestServiceSettings serviceSettings
+        ) {
+            super(
+                new ModelConfigurations(inferenceEntityId, TaskType.SPARSE_EMBEDDING, TestInferenceService.NAME, serviceSettings),
+                new ModelSecrets(new AbstractTestInferenceService.TestSecretSettings("api_key"))
+            );
+        }
+    }
+
     public static class TestInferenceService extends AbstractTestInferenceService {
-        private static final String NAME = "test_service";
+        public static final String NAME = "test_service";
 
         public TestInferenceService(InferenceServiceExtension.InferenceServiceFactoryContext context) {}
 

--- a/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/TestSparseInferenceServiceExtension.java
+++ b/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/TestSparseInferenceServiceExtension.java
@@ -46,11 +46,7 @@ public class TestSparseInferenceServiceExtension implements InferenceServiceExte
     }
 
     public static class TestSparseModel extends Model {
-
-        public TestSparseModel(
-            String inferenceEntityId,
-            TestServiceSettings serviceSettings
-        ) {
+        public TestSparseModel(String inferenceEntityId, TestServiceSettings serviceSettings) {
             super(
                 new ModelConfigurations(inferenceEntityId, TaskType.SPARSE_EMBEDDING, TestInferenceService.NAME, serviceSettings),
                 new ModelSecrets(new AbstractTestInferenceService.TestSecretSettings("api_key"))
@@ -135,7 +131,7 @@ public class TestSparseInferenceServiceExtension implements InferenceServiceExte
             for (int i = 0; i < input.size(); i++) {
                 var tokens = new ArrayList<SparseEmbeddingResults.WeightedToken>();
                 for (int j = 0; j < 5; j++) {
-                    tokens.add(new SparseEmbeddingResults.WeightedToken("feature_" + j, stringWeight(input.get(i), j)));
+                    tokens.add(new SparseEmbeddingResults.WeightedToken("feature_" + j, generateEmbedding(input.get(i), j)));
                 }
                 embeddings.add(new SparseEmbeddingResults.Embedding(tokens, false));
             }
@@ -147,7 +143,7 @@ public class TestSparseInferenceServiceExtension implements InferenceServiceExte
             for (int i = 0; i < input.size(); i++) {
                 var tokens = new ArrayList<TextExpansionResults.WeightedToken>();
                 for (int j = 0; j < 5; j++) {
-                    tokens.add(new TextExpansionResults.WeightedToken("feature_" + j, stringWeight(input.get(i), j)));
+                    tokens.add(new TextExpansionResults.WeightedToken("feature_" + j, generateEmbedding(input.get(i), j)));
                 }
                 results.add(
                     new ChunkedSparseEmbeddingResults(List.of(new ChunkedTextExpansionResults.ChunkedResult(input.get(i), tokens)))
@@ -158,6 +154,11 @@ public class TestSparseInferenceServiceExtension implements InferenceServiceExte
 
         protected ServiceSettings getServiceSettingsFromMap(Map<String, Object> serviceSettingsMap) {
             return TestServiceSettings.fromMap(serviceSettingsMap);
+        }
+
+        private static float generateEmbedding(String input, int position) {
+            // Ensure non-negative and non-zero values for features
+            return Math.abs(input.hashCode()) + 1 + position;
         }
     }
 

--- a/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilterIT.java
+++ b/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilterIT.java
@@ -130,34 +130,34 @@ public class ShardBulkInferenceActionFilterIT extends ESIntegTestCase {
     }
 
     private void storeSparseModel() throws Exception {
-        ModelRegistry modelRegistry = new ModelRegistry(client());
-
-        String inferenceEntityId = TestSparseInferenceServiceExtension.TestInferenceService.NAME;
         Model model = new TestSparseInferenceServiceExtension.TestSparseModel(
-            inferenceEntityId,
-            new TestSparseInferenceServiceExtension.TestServiceSettings(inferenceEntityId, null, false)
+            TestSparseInferenceServiceExtension.TestInferenceService.NAME,
+            new TestSparseInferenceServiceExtension.TestServiceSettings(
+                TestSparseInferenceServiceExtension.TestInferenceService.NAME,
+                null,
+                false
+            )
         );
-        AtomicReference<Boolean> storeModelHolder = new AtomicReference<>();
-        AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
-
-        blockingCall(listener -> modelRegistry.storeModel(model, listener), storeModelHolder, exceptionHolder);
-
-        assertThat(storeModelHolder.get(), is(true));
-        assertThat(exceptionHolder.get(), is(nullValue()));
+        storeModel(model);
     }
 
     private void storeDenseModel() throws Exception {
-        ModelRegistry modelRegistry = new ModelRegistry(client());
-
-        String inferenceEntityId = TestDenseInferenceServiceExtension.TestInferenceService.NAME;
         Model model = new TestDenseInferenceServiceExtension.TestDenseModel(
-            inferenceEntityId,
+            TestDenseInferenceServiceExtension.TestInferenceService.NAME,
             new TestDenseInferenceServiceExtension.TestServiceSettings(
-                inferenceEntityId,
+                TestDenseInferenceServiceExtension.TestInferenceService.NAME,
                 randomIntBetween(1, 100),
+                // dot product means that we need normalized vectors; it's not worth doing that in this test
                 randomValueOtherThan(SimilarityMeasure.DOT_PRODUCT, () -> randomFrom(SimilarityMeasure.values()))
             )
         );
+
+        storeModel(model);
+    }
+
+    private void storeModel(Model model) throws Exception {
+        ModelRegistry modelRegistry = new ModelRegistry(client());
+
         AtomicReference<Boolean> storeModelHolder = new AtomicReference<>();
         AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
 

--- a/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilterIT.java
+++ b/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilterIT.java
@@ -1,12 +1,13 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
  */
 
 package org.elasticsearch.xpack.inference.action.filter;
+
+import com.carrotsearch.randomizedtesting.annotations.Repeat;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
@@ -21,6 +22,7 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.inference.InferenceServiceExtension;
 import org.elasticsearch.inference.Model;
+import org.elasticsearch.inference.SimilarityMeasure;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -33,6 +35,7 @@ import org.junit.Before;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -49,7 +52,8 @@ public class ShardBulkInferenceActionFilterIT extends ESIntegTestCase {
 
     @Before
     public void setup() throws Exception {
-        storeModel();
+        storeSparseModel();
+        storeDenseModel();
     }
 
     @Override
@@ -57,45 +61,41 @@ public class ShardBulkInferenceActionFilterIT extends ESIntegTestCase {
         return Arrays.asList(TestInferencePlugin.class);
     }
 
+    @Repeat(iterations = 1000)
     public void testBulkOperations() throws Exception {
         Map<String, Integer> shardsSettings = Collections.singletonMap(IndexMetadata.SETTING_NUMBER_OF_SHARDS, randomIntBetween(1, 10));
-        indicesAdmin().prepareCreate(INDEX_NAME)
-            .setMapping("""
-                {
-                    "properties": {
-                        "foo": {
-                            "type": "semantic_text",
-                            "inference_id": "test-inference"
-                        }
+        indicesAdmin().prepareCreate(INDEX_NAME).setMapping("""
+            {
+                "properties": {
+                    "sparse_field": {
+                        "type": "semantic_text",
+                        "inference_id": "test_service"
+                    },
+                    "dense_field": {
+                        "type": "semantic_text",
+                        "inference_id": "text_embedding_test_service"
                     }
                 }
-                """)
-            .setSettings(shardsSettings)
-            .get();
+            }
+            """).setSettings(shardsSettings).get();
 
         int totalBulkReqs = randomIntBetween(2, 100);
         long totalDocs = 0;
-        for(int bulkReqs = 0; bulkReqs < totalBulkReqs; bulkReqs++) {
+        for (int bulkReqs = 0; bulkReqs < totalBulkReqs; bulkReqs++) {
             BulkRequestBuilder bulkReqBuilder = client().prepareBulk();
             int totalBulkSize = randomIntBetween(1, 100);
-            for(int bulkSize = 0; bulkSize < totalBulkSize; bulkSize++) {
+            for (int bulkSize = 0; bulkSize < totalBulkSize; bulkSize++) {
                 String id = Long.toString(totalDocs);
                 boolean isIndexRequest = randomBoolean();
-                String fieldValue = isIndexRequest && rarely() ? null : randomAlphaOfLengthBetween(0, 1000);
-                Map<String, Object> source = Collections.singletonMap("foo", fieldValue);
+                Map<String, Object> source = new HashMap<>();
+                source.put("sparse_field", isIndexRequest && rarely() ? null : randomAlphaOfLengthBetween(0, 1000));
+                source.put("dense_field", isIndexRequest && rarely() ? null : randomAlphaOfLengthBetween(0, 1000));
                 if (isIndexRequest) {
-                    bulkReqBuilder.add(
-                        new IndexRequestBuilder(client())
-                            .setIndex(INDEX_NAME)
-                            .setId(id)
-                            .setSource(source)
-                    );
+                    bulkReqBuilder.add(new IndexRequestBuilder(client()).setIndex(INDEX_NAME).setId(id).setSource(source));
                     totalDocs++;
                 } else {
                     boolean isUpsert = randomBoolean();
-                    UpdateRequestBuilder request = new UpdateRequestBuilder(client())
-                        .setIndex(INDEX_NAME)
-                        .setDoc(source);
+                    UpdateRequestBuilder request = new UpdateRequestBuilder(client()).setIndex(INDEX_NAME).setDoc(source);
                     if (isUpsert || totalDocs == 0) {
                         request.setDocAsUpsert(true);
                         totalDocs++;
@@ -112,7 +112,7 @@ public class ShardBulkInferenceActionFilterIT extends ESIntegTestCase {
                 // Get more details in case something fails
                 for (BulkItemResponse bulkItemResponse : bulkResponse.getItems()) {
                     if (bulkItemResponse.isFailed()) {
-                         fail(
+                        fail(
                             bulkItemResponse.getFailure().getCause(),
                             "Failed to index document %s: %s",
                             bulkItemResponse.getId(),
@@ -132,13 +132,34 @@ public class ShardBulkInferenceActionFilterIT extends ESIntegTestCase {
         searchResponse.decRef();
     }
 
-    private void storeModel() throws Exception {
+    private void storeSparseModel() throws Exception {
         ModelRegistry modelRegistry = new ModelRegistry(client());
 
-        String inferenceEntityId = "test-inference";
+        String inferenceEntityId = TestSparseInferenceServiceExtension.TestInferenceService.NAME;
         Model model = new TestSparseInferenceServiceExtension.TestSparseModel(
             inferenceEntityId,
             new TestSparseInferenceServiceExtension.TestServiceSettings(inferenceEntityId, null, false)
+        );
+        AtomicReference<Boolean> storeModelHolder = new AtomicReference<>();
+        AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
+
+        blockingCall(listener -> modelRegistry.storeModel(model, listener), storeModelHolder, exceptionHolder);
+
+        assertThat(storeModelHolder.get(), is(true));
+        assertThat(exceptionHolder.get(), is(nullValue()));
+    }
+
+    private void storeDenseModel() throws Exception {
+        ModelRegistry modelRegistry = new ModelRegistry(client());
+
+        String inferenceEntityId = TestDenseInferenceServiceExtension.TestInferenceService.NAME;
+        Model model = new TestDenseInferenceServiceExtension.TestDenseModel(
+            inferenceEntityId,
+            new TestDenseInferenceServiceExtension.TestServiceSettings(
+                inferenceEntityId,
+                randomIntBetween(1, 100),
+                randomFrom(SimilarityMeasure.values())
+            )
         );
         AtomicReference<Boolean> storeModelHolder = new AtomicReference<>();
         AtomicReference<Exception> exceptionHolder = new AtomicReference<>();

--- a/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilterIT.java
+++ b/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilterIT.java
@@ -7,8 +7,6 @@
 
 package org.elasticsearch.xpack.inference.action.filter;
 
-import com.carrotsearch.randomizedtesting.annotations.Repeat;
-
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.action.bulk.BulkItemResponse;
@@ -61,7 +59,6 @@ public class ShardBulkInferenceActionFilterIT extends ESIntegTestCase {
         return Arrays.asList(TestInferencePlugin.class);
     }
 
-    @Repeat(iterations = 1000)
     public void testBulkOperations() throws Exception {
         Map<String, Integer> shardsSettings = Collections.singletonMap(IndexMetadata.SETTING_NUMBER_OF_SHARDS, randomIntBetween(1, 10));
         indicesAdmin().prepareCreate(INDEX_NAME).setMapping("""
@@ -158,7 +155,7 @@ public class ShardBulkInferenceActionFilterIT extends ESIntegTestCase {
             new TestDenseInferenceServiceExtension.TestServiceSettings(
                 inferenceEntityId,
                 randomIntBetween(1, 100),
-                randomFrom(SimilarityMeasure.values())
+                randomValueOtherThan(SimilarityMeasure.DOT_PRODUCT, () -> randomFrom(SimilarityMeasure.values()))
             )
         );
         AtomicReference<Boolean> storeModelHolder = new AtomicReference<>();

--- a/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilterIT.java
+++ b/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilterIT.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.xpack.inference.action.filter;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
+import org.elasticsearch.action.bulk.BulkItemResponse;
+import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.update.UpdateRequestBuilder;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.inference.InferenceServiceExtension;
+import org.elasticsearch.inference.Model;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.xpack.inference.InferencePlugin;
+import org.elasticsearch.xpack.inference.mock.TestDenseInferenceServiceExtension;
+import org.elasticsearch.xpack.inference.mock.TestSparseInferenceServiceExtension;
+import org.elasticsearch.xpack.inference.registry.ModelRegistry;
+import org.junit.Before;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+public class ShardBulkInferenceActionFilterIT extends ESIntegTestCase {
+
+    public static final String INDEX_NAME = "test-index";
+
+    @Before
+    public void setup() throws Exception {
+        storeModel();
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Arrays.asList(TestInferencePlugin.class);
+    }
+
+    public void testBulkOperations() throws Exception {
+        Map<String, Integer> shardsSettings = Collections.singletonMap(IndexMetadata.SETTING_NUMBER_OF_SHARDS, randomIntBetween(1, 10));
+        indicesAdmin().prepareCreate(INDEX_NAME)
+            .setMapping("""
+                {
+                    "properties": {
+                        "foo": {
+                            "type": "semantic_text",
+                            "inference_id": "test-inference"
+                        }
+                    }
+                }
+                """)
+            .setSettings(shardsSettings)
+            .get();
+
+        int totalBulkReqs = randomIntBetween(2, 100);
+        long totalDocs = 0;
+        for(int bulkReqs = 0; bulkReqs < totalBulkReqs; bulkReqs++) {
+            BulkRequestBuilder bulkReqBuilder = client().prepareBulk();
+            int totalBulkSize = randomIntBetween(1, 100);
+            for(int bulkSize = 0; bulkSize < totalBulkSize; bulkSize++) {
+                String id = Long.toString(totalDocs);
+                boolean isIndexRequest = randomBoolean();
+                String fieldValue = isIndexRequest && rarely() ? null : randomAlphaOfLengthBetween(0, 1000);
+                Map<String, Object> source = Collections.singletonMap("foo", fieldValue);
+                if (isIndexRequest) {
+                    bulkReqBuilder.add(
+                        new IndexRequestBuilder(client())
+                            .setIndex(INDEX_NAME)
+                            .setId(id)
+                            .setSource(source)
+                    );
+                    totalDocs++;
+                } else {
+                    boolean isUpsert = randomBoolean();
+                    UpdateRequestBuilder request = new UpdateRequestBuilder(client())
+                        .setIndex(INDEX_NAME)
+                        .setDoc(source);
+                    if (isUpsert || totalDocs == 0) {
+                        request.setDocAsUpsert(true);
+                        totalDocs++;
+                    } else {
+                        // Update already existing document
+                        id = Long.toString(randomLongBetween(0, totalDocs - 1));
+                    }
+                    request.setId(id);
+                    bulkReqBuilder.add(request);
+                }
+            }
+            BulkResponse bulkResponse = bulkReqBuilder.get();
+            if (bulkResponse.hasFailures()) {
+                // Get more details in case something fails
+                for (BulkItemResponse bulkItemResponse : bulkResponse.getItems()) {
+                    if (bulkItemResponse.isFailed()) {
+                         fail(
+                            bulkItemResponse.getFailure().getCause(),
+                            "Failed to index document %s: %s",
+                            bulkItemResponse.getId(),
+                            bulkItemResponse.getFailureMessage()
+                        );
+                    }
+                }
+            }
+            assertFalse(bulkResponse.hasFailures());
+        }
+
+        client().admin().indices().refresh(new RefreshRequest(INDEX_NAME)).get();
+
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().size(0).trackTotalHits(true);
+        SearchResponse searchResponse = client().search(new SearchRequest(INDEX_NAME).source(sourceBuilder)).get();
+        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(totalDocs));
+        searchResponse.decRef();
+    }
+
+    private void storeModel() throws Exception {
+        ModelRegistry modelRegistry = new ModelRegistry(client());
+
+        String inferenceEntityId = "test-inference";
+        Model model = new TestSparseInferenceServiceExtension.TestSparseModel(
+            inferenceEntityId,
+            new TestSparseInferenceServiceExtension.TestServiceSettings(inferenceEntityId, null, false)
+        );
+        AtomicReference<Boolean> storeModelHolder = new AtomicReference<>();
+        AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
+
+        blockingCall(listener -> modelRegistry.storeModel(model, listener), storeModelHolder, exceptionHolder);
+
+        assertThat(storeModelHolder.get(), is(true));
+        assertThat(exceptionHolder.get(), is(nullValue()));
+    }
+
+    private <T> void blockingCall(Consumer<ActionListener<T>> function, AtomicReference<T> response, AtomicReference<Exception> error)
+        throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+        ActionListener<T> listener = ActionListener.wrap(r -> {
+            response.set(r);
+            latch.countDown();
+        }, e -> {
+            error.set(e);
+            latch.countDown();
+        });
+
+        function.accept(listener);
+        latch.await();
+    }
+
+    public static class TestInferencePlugin extends InferencePlugin {
+        public TestInferencePlugin(Settings settings) {
+            super(settings);
+        }
+
+        @Override
+        public List<InferenceServiceExtension.Factory> getInferenceServiceFactories() {
+            return List.of(
+                TestSparseInferenceServiceExtension.TestInferenceService::new,
+                TestDenseInferenceServiceExtension.TestInferenceService::new
+            );
+        }
+    }
+}


### PR DESCRIPTION
Created an IT for bulk ingestion using semantic_text.

Base branch is the [current open PR](https://github.com/elastic/elasticsearch/pull/108102) for ingestion. I'd prefer to merge that first before this one to avoid noise, and open it as a follow up.

I've done an IT that mixes bulk operations (index, update, upsert) on an index, and tests the number of documents in the index. I've relied heavily on randomness to get test coverage.

